### PR TITLE
Exclude specs from coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - busted --verbose --coverage
 
 after_success:
-  - luacov-coveralls --exclude $TRAVIS_BUILD_DIR/lua_install
+  - luacov-coveralls -e spec/ -e $TRAVIS_BUILD_DIR/lua_install
 
 branches:
   except:


### PR DESCRIPTION
I noticed [here](https://coveralls.io/builds/10429918/source?filename=spec%2Fanim8%2Fanimation_spec.lua) that the spec file was being included in the coverage report, which taints the overall coverage percentage of the report. The coverage of spec files is useless information because it's always going to be 100% since the test runner will always run everything in it.