### PR TITLE
anim8: Print float framecounts using %f

### DIFF
--- a/anim8.lua
+++ b/anim8.lua
@@ -35,7 +35,7 @@ local _frames = {}
 local function assertPositiveInteger(value, name)
   if type(value) ~= 'number' then error(("%s should be a number, was %q"):format(name, tostring(value))) end
   if value < 1 then error(("%s should be a positive number, was %d"):format(name, value)) end
-  if value ~= math.floor(value) then error(("%s should be an integer, was %d"):format(name, value)) end
+  if value ~= math.floor(value) then error(("%s should be an integer, was %f"):format(name, value)) end
 end
 
 local function createFrame(self, x, y)


### PR DESCRIPTION
Ensure the print shows that the input value was a float. With %d it prints as an integer which looks correct when the error says it's not.